### PR TITLE
Solve build errors involving Maven plugin in Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,4 +3,4 @@ jdk:
 before_install:
   - chmod +x gradlew
 install:
-  - ./gradlew build :{library}:publishToMavenLocal
+  - ./gradlew build :library:publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,6 @@
 jdk:
   - openjdk11
+before_install:
+  - chmod +x gradlew
+install:
+  - ./gradlew build :{library}:publishToMavenLocal

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion 31
@@ -30,4 +31,14 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+            }
+        }
+    }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -38,6 +38,9 @@ project.afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
+                groupId = 'in.basulabs.audiofocuscontroller'
+                artifactId = 'library'
+                version = '2.0'
             }
         }
     }


### PR DESCRIPTION
First, Gradle 7.0+ requires JDK 11+. This has been fixed in 78309ce.

Next comes the errors with Maven plugin, noted in [this SO question](https://stackoverflow.com/q/67599438/8387076). The current version of `jitpack.yml` and library-level `build.gradle` fixes the errors. Also noteworthy: https://github.com/MohammedAbidNafi/iOS-Style-Alert-Dialog/commit/61bece6858b796ed767578c3e2a1a398cb5d151b#r57286369

Note that each time the library is updated, the Maven version code must be changed.