### PR TITLE
Add license info to POM

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -52,6 +52,14 @@ publishing {
             afterEvaluate {
                 from components.release
             }
+            pom {
+                licenses {
+                    license {
+                        name = 'MPL-2.0'
+                        url = 'https://mozilla.org/MPL/2.0/'
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Add license information (MPL-2.0) to the artifact POM, closes #18.

This PR is a second iteration of #19.